### PR TITLE
BGD-3813 - limit the number of executors

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ var (
 	workqueueTokenRefillRate       = flag.Int("workqueue-token-refill-rate", 50, "")
 	workqueueTokenBucketSize       = flag.Int("workqueue-token-bucket-size", 500, "")
 	workqueueMaxDelay              = flag.Duration("workqueue-max-delay", rate.InfDuration, "")
+	executorsProcessingLimit       = flag.Int("executors-processing-limit", 5000, "Limit the number of executors that the spark-operator processes")
 	metricsLabels                  util.ArrayFlags
 	metricsJobStartLatencyBuckets  util.HistogramBuckets = util.DefaultJobStartLatencyBuckets
 )
@@ -206,7 +207,7 @@ func main() {
 	}
 
 	applicationController := sparkapplication.NewController(
-		crClient, kubeClient, crInformerFactory, podInformerFactory, metricConfig, *namespace, *ingressURLFormat, *ingressClassName, batchSchedulerMgr, *enableUIService, *disableExecutorReporting, workqueueRateLimitCfg)
+		crClient, kubeClient, crInformerFactory, podInformerFactory, metricConfig, *namespace, *ingressURLFormat, *ingressClassName, batchSchedulerMgr, *enableUIService, *disableExecutorReporting, workqueueRateLimitCfg, *executorsProcessingLimit)
 	scheduledApplicationController := scheduledsparkapplication.NewController(
 		crClient, kubeClient, apiExtensionsClient, crInformerFactory, clock.RealClock{})
 

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ var (
 	workqueueTokenRefillRate       = flag.Int("workqueue-token-refill-rate", 50, "")
 	workqueueTokenBucketSize       = flag.Int("workqueue-token-bucket-size", 500, "")
 	workqueueMaxDelay              = flag.Duration("workqueue-max-delay", rate.InfDuration, "")
-	executorsProcessingLimit       = flag.Int("executors-processing-limit", 5000, "Limit the number of executors that the spark-operator processes")
+	executorsProcessingLimit       = flag.Int("executors-processing-limit", 5000, "Limit the number of executors that the spark-operator processes per application")
 	metricsLabels                  util.ArrayFlags
 	metricsJobStartLatencyBuckets  util.HistogramBuckets = util.DefaultJobStartLatencyBuckets
 )

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -54,6 +54,8 @@ const (
 	SparkExecutorRole = "executor"
 	// SubmissionIDLabel is the label that records the submission ID of the current run of an application.
 	SubmissionIDLabel = LabelAnnotationPrefix + "submission-id"
+	// SparkExecutorIDLabel is the label that records executor pod ID
+	SparkExecutorIDLabel = "spark-exec-id"
 )
 
 const (

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -406,7 +406,7 @@ func (c *Controller) getAndUpdateExecutorState(app *v1beta2.SparkApplication) er
 					c.recordExecutorEvent(app, newState, pod.Name)
 				}
 			}
-			//if the executor number is higher than the `executorsProcessingLimit` we want to stop persisting executors
+			// If the executor number is higher than the `executorsProcessingLimit` we want to stop persisting executors
 			if executorID, _ := strconv.Atoi(getSparkExecutorID(pod)); executorID <= c.executorsProcessingLimit {
 				executorStateMap[pod.Name] = newState
 			}

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -388,32 +388,31 @@ func (c *Controller) getAndUpdateExecutorState(app *v1beta2.SparkApplication) er
 	executorStateMap := make(map[string]v1beta2.ExecutorState)
 	var executorApplicationID string
 	for _, pod := range pods {
-		if util.IsExecutorPod(pod) {
-			// If the executor number is higher than the `executorsProcessingLimit` we want to stop persisting executors
-			if executorID, _ := strconv.Atoi(getSparkExecutorID(pod)); executorID <= c.executorsProcessingLimit {
-				newState := podPhaseToExecutorState(pod.Status.Phase)
-				oldState, exists := app.Status.ExecutorState[pod.Name]
-				// Only record an executor event if the executor state is new or it has changed.
-				if !exists || newState != oldState {
-					if newState == v1beta2.ExecutorFailedState {
-						execContainerState := getExecutorContainerTerminatedState(pod.Status)
-						if execContainerState != nil {
-							c.recordExecutorEvent(app, newState, pod.Name, execContainerState.ExitCode, execContainerState.Reason)
-						} else {
-							// If we can't find the container state,
-							// we need to set the exitCode and the Reason to unambiguous values.
-							c.recordExecutorEvent(app, newState, pod.Name, -1, "Unknown (Container not Found)")
-						}
-					} else {
-						c.recordExecutorEvent(app, newState, pod.Name)
-					}
+		// If the executor number is higher than the `executorsProcessingLimit` we want to stop persisting executors
+		if executorID, _ := strconv.Atoi(getSparkExecutorID(pod)); executorID > c.executorsProcessingLimit {
+			continue
+		}
+		newState := podPhaseToExecutorState(pod.Status.Phase)
+		oldState, exists := app.Status.ExecutorState[pod.Name]
+		// Only record an executor event if the executor state is new or it has changed.
+		if !exists || newState != oldState {
+			if newState == v1beta2.ExecutorFailedState {
+				execContainerState := getExecutorContainerTerminatedState(pod.Status)
+				if execContainerState != nil {
+					c.recordExecutorEvent(app, newState, pod.Name, execContainerState.ExitCode, execContainerState.Reason)
+				} else {
+					// If we can't find the container state,
+					// we need to set the exitCode and the Reason to unambiguous values.
+					c.recordExecutorEvent(app, newState, pod.Name, -1, "Unknown (Container not Found)")
 				}
-				executorStateMap[pod.Name] = newState
-
-				if executorApplicationID == "" {
-					executorApplicationID = getSparkApplicationID(pod)
-				}
+			} else {
+				c.recordExecutorEvent(app, newState, pod.Name)
 			}
+		}
+		executorStateMap[pod.Name] = newState
+
+		if executorApplicationID == "" {
+			executorApplicationID = getSparkApplicationID(pod)
 		}
 	}
 

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -926,6 +926,7 @@ func TestSyncSparkApplication_SubmissionSuccess(t *testing.T) {
 
 func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 	type testcase struct {
+		name                    string
 		appName                 string
 		oldAppStatus            v1beta2.ApplicationStateType
 		oldExecutorStatus       map[string]v1beta2.ExecutorState
@@ -967,6 +968,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 
 	testcases := []testcase{
 		{
+			name:                  appName,
 			appName:               appName,
 			oldAppStatus:          v1beta2.SubmittedState,
 			oldExecutorStatus:     map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
@@ -980,6 +982,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.SubmittedState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
@@ -1021,6 +1024,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.RunningState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
@@ -1076,6 +1080,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.RunningState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
@@ -1133,6 +1138,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.RunningState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
@@ -1191,6 +1197,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.RunningState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
@@ -1254,6 +1261,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.RunningState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
@@ -1314,6 +1322,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 		},
 		{
+			name:                    appName,
 			appName:                 appName,
 			oldAppStatus:            v1beta2.FailingState,
 			oldExecutorStatus:       map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorFailedState},
@@ -1323,6 +1332,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			expectedExecutorMetrics: executorMetrics{},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.RunningState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
@@ -1364,6 +1374,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 		},
 		{
+			name:                    appName,
 			appName:                 appName,
 			oldAppStatus:            v1beta2.SucceedingState,
 			oldExecutorStatus:       map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorCompletedState},
@@ -1373,6 +1384,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			expectedExecutorMetrics: executorMetrics{},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.SubmittedState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{},
@@ -1408,6 +1420,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			expectedExecutorMetrics: executorMetrics{},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.CompletedState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorPendingState},
@@ -1433,6 +1446,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 		},
 		{
+			name:              appName,
 			appName:           appName,
 			oldAppStatus:      v1beta2.RunningState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
@@ -1456,6 +1470,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			expectedExecutorMetrics: executorMetrics{},
 		},
 		{
+			name:         appName,
 			appName:      appName,
 			oldAppStatus: v1beta2.SubmittedState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{
@@ -1507,6 +1522,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			expectedExecutorMetrics: executorMetrics{},
 		},
 		{
+			name:         "when_executorsProcessingLimit_isSet_then_disableExecutorProcessing",
 			appName:      appName,
 			oldAppStatus: v1beta2.SubmittedState,
 			oldExecutorStatus: map[string]v1beta2.ExecutorState{
@@ -1607,7 +1623,9 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		testFn(test, t)
+		t.Run(test.name, func(tt *testing.T) {
+			testFn(test, tt)
+		})
 	}
 }
 

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -68,7 +68,7 @@ func newFakeController(app *v1beta2.SparkApplication, pods ...*apiv1.Pod) (*Cont
 
 	podInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0*time.Second)
 	controller := newSparkApplicationController(crdClient, kubeClient, informerFactory, podInformerFactory, recorder,
-		&util.MetricConfig{}, "", "", nil, true, false, util.RatelimitConfig{})
+		&util.MetricConfig{}, "", "", nil, true, false, util.RatelimitConfig{}, 5)
 
 	informer := informerFactory.Sparkoperator().V1beta2().SparkApplications().Informer()
 	if app != nil {
@@ -1453,6 +1453,107 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			expectedAppState:        v1beta2.RunningState,
 			expectedExecutorState:   map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorUnknownState},
 			expectedAppMetrics:      metrics{},
+			expectedExecutorMetrics: executorMetrics{},
+		},
+		{
+			appName:      appName,
+			oldAppStatus: v1beta2.SubmittedState,
+			oldExecutorStatus: map[string]v1beta2.ExecutorState{
+				"exec-1": v1beta2.ExecutorRunningState,
+				"exec-2": v1beta2.ExecutorRunningState,
+				"exec-3": v1beta2.ExecutorRunningState,
+				"exec-4": v1beta2.ExecutorRunningState,
+				"exec-5": v1beta2.ExecutorRunningState,
+			},
+			driverPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      driverPodName,
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkDriverRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodRunning,
+				},
+			},
+			executorPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "exec-6",
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:       config.SparkExecutorRole,
+						config.SparkAppNameLabel:    appName,
+						config.SparkExecutorIDLabel: "6",
+					},
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodPending,
+				},
+			},
+			expectedAppState: v1beta2.RunningState,
+			expectedExecutorState: map[string]v1beta2.ExecutorState{
+				"exec-1": v1beta2.ExecutorUnknownState,
+				"exec-2": v1beta2.ExecutorUnknownState,
+				"exec-3": v1beta2.ExecutorUnknownState,
+				"exec-4": v1beta2.ExecutorUnknownState,
+				"exec-5": v1beta2.ExecutorUnknownState,
+			},
+			expectedAppMetrics: metrics{
+				runningMetricCount: 1,
+			},
+			expectedExecutorMetrics: executorMetrics{},
+		},
+		{
+			appName:      appName,
+			oldAppStatus: v1beta2.SubmittedState,
+			oldExecutorStatus: map[string]v1beta2.ExecutorState{
+				"exec-1": v1beta2.ExecutorRunningState,
+				"exec-2": v1beta2.ExecutorRunningState,
+				"exec-3": v1beta2.ExecutorRunningState,
+				"exec-4": v1beta2.ExecutorRunningState,
+			},
+			driverPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      driverPodName,
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkDriverRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodRunning,
+				},
+			},
+			executorPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "exec-5",
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:       config.SparkExecutorRole,
+						config.SparkAppNameLabel:    appName,
+						config.SparkExecutorIDLabel: "5",
+					},
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodPending,
+				},
+			},
+			expectedAppState: v1beta2.RunningState,
+			expectedExecutorState: map[string]v1beta2.ExecutorState{
+				"exec-1": v1beta2.ExecutorUnknownState,
+				"exec-2": v1beta2.ExecutorUnknownState,
+				"exec-3": v1beta2.ExecutorUnknownState,
+				"exec-4": v1beta2.ExecutorUnknownState,
+				"exec-5": v1beta2.ExecutorPendingState,
+			},
+			expectedAppMetrics: metrics{
+				runningMetricCount: 1,
+			},
 			expectedExecutorMetrics: executorMetrics{},
 		},
 	}

--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -43,6 +43,10 @@ func getSparkApplicationID(pod *apiv1.Pod) string {
 	return pod.Labels[config.SparkApplicationSelectorLabel]
 }
 
+func getSparkExecutorID(pod *apiv1.Pod) string {
+	return pod.Labels[config.SparkExecutorIDLabel]
+}
+
 func getDriverPodName(app *v1beta2.SparkApplication) string {
 	name := app.Spec.Driver.PodName
 	if name != nil && len(*name) > 0 {


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/3813

## Description

We should cap the number of executors that the spark-operator processes and the size of the executors list in the SparkApplication CR status section
This will make sure that we do not DoS attack ourselves indefinitely by slowing down the SparkApplication CR processing (submitting apps and tracking driver pods is the highest priority of the spark-operator) and also that the executor list in the CR does not grow too large, causing `etcd` errors when we try to patch / update the CR

## Demo

run the spark-operator with the `--executors-processing-limit=5` argument, which will limit the number of processed executors  to `5`

https://github.com/spotinst/spark-on-k8s-operator/assets/54230036/94f8bbeb-12cb-4ec8-9311-6f49fa5d5ea5



## Checklist
- [ ] I have added a Jira ticket link
- [ ] I have filled in the test plan
- [ ] I have executed the tests and filled in the test results
- [ ] (For release PRs) I have reviewed the [data plane release instructions](https://spotinst.atlassian.net/wiki/spaces/BD/pages/2780692657/Data+Plane+Release)
- [ ] (For release PRs) I have updated the changelog (infra/setup/CHANGELOG.md)
- [ ] (For release PRs) I have/will create a changelog PR in the documentation repo ([spotinst/help](https://github.com/spotinst/help/blob/master/src/docs/ocean-spark/data-plane-release-notes/README.md))

## How to test

_Description of environment setup necessary to exercise the feature and perform tests_

## Test plan and results

_Feel free to add screenshots showing test results_

| Test | Description       | Result | Notes                      |
|------|-------------------|--------|----------------------------|
| 1     | Test with input A | Pass   | Some notes about the test  |
| 2    | Test with input B | Pass   | Some notes about the test  |
| 3    | Test with input C | Pass   | Some notes about the test  |