### PR TITLE
[.github/actions/release] update spark base image in the operator

### DIFF
--- a/.github/actions/release/Makefile
+++ b/.github/actions/release/Makefile
@@ -3,8 +3,8 @@ BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 VERSION = $(shell git rev-parse --short=7 HEAD)
 IMAGE_NAME = spark-operator
-SPARK_BASE_IMAGE = gcr.io/ocean-spark/spark:platform-3.4-gen20
-TAG = $(VERSION)-gen20
+SPARK_BASE_IMAGE = gcr.io/ocean-spark/spark:platform-3.4-gen23-rc11
+TAG = $(VERSION)-gen23-rc11
 SPARK_BASE_IMAGE_RH = public.ecr.aws/f4k1p1n4/spark:netapp-spark-support-image-v3.5-rel20240315
 TAG_RH = $(VERSION)-ubi9-rel20240315
 


### PR DESCRIPTION
Move from vulnerable `gcr.io/ocean-spark/spark:platform-3.4-gen20` image (see thread https://spotinst.slack.com/archives/C027NDRGA7P/p1720635885317539) to `platform-3.4-gen23-rc11 ` image to patch a HIGH https://avd.aquasec.com/nvd/2024/cve-2024-6387/ issue

##  JIRA Ticket:

- https://spotinst.atlassian.net/browse/BGD-5482

## Tests:

- Updated the demo-0 spark operator image to use the image built from the CI in this PR : 
`public.ecr.aws/n8e8v3t5/spark-operator:BGD-5482-scan-of-2024-07-08-fix-vulnerabilities-discovered-in-spark-operator-ocean-spark` (accessible from demo-0 which is in prod since the ECR is public)


<img width="3336" alt="Screenshot 2024-07-11 at 16 16 01" src="https://github.com/spotinst/spark-on-k8s-operator/assets/35115877/7915aab9-bc73-460e-af7d-06c95f3b88cd">



- Trigger the integration tests: 
     - integration tests triggered here : https://github.com/spotinst/bigdata-internal-charts/actions/runs/9892678911/job/27325940981 
    - re-run ✅:  https://github.com/spotinst/bigdata-internal-charts/actions/runs/9892678911/job/27326514471 