### PR TITLE
[.github] fix the image tag in the trivy scanner workflow

### DIFF
--- a/.github/workflows/trivy-image-scanning.yaml
+++ b/.github/workflows/trivy-image-scanning.yaml
@@ -7,7 +7,7 @@ on:
 env:
   PUBLIC_ECR: public.ecr.aws/ocean-spark
   IMAGE_NAME: spark-operator
-  IMAGE_TAG: main
+  IMAGE_TAG: ocean-spark
 
 jobs:
   public-ecr-scan:


### PR DESCRIPTION
Follows https://github.com/spotinst/spark-on-k8s-operator/pull/26 
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-5837

## Description

- Create a dedicated workflow for scanning CP images in each repo. This will make the results more visible when they are pulled by Armor Code.
- Add JIRA secrets to OfAS repos.